### PR TITLE
Fix role-play paths, aggregate matching, and dimension descriptions

### DIFF
--- a/calculations/Avg Quarterly Store Sales for 1998-1999.yml
+++ b/calculations/Avg Quarterly Store Sales for 1998-1999.yml
@@ -4,5 +4,5 @@ label: Avg Quarterly Store Sales for 1998-1999
 description: "Fixed baseline: average Total Store Sales per Sold calendar quarter, Q1 1998 through Q1 1999. Used as denominator in Avg Quarter Sales Ratio; not a current-period measure."
 expression: |-
   Avg(
-  [Sold Date Dimensions].[Sold Date Dimensions].[Sold Calendar Quarter].&[1998-02-01]:[Sold Date Dimensions].[Sold Date Dimensions].[Sold Calendar Quarter].&[1999-02-01],
+  [Sold Date Dimensions].[Sold Date Dimensions].[Sold Calendar Quarter].&[1998-01-01]:[Sold Date Dimensions].[Sold Date Dimensions].[Sold Calendar Quarter].&[1999-01-01],
   [Measures].[Total Store Sales])

--- a/datasets/catalog_sales.yml
+++ b/datasets/catalog_sales.yml
@@ -84,10 +84,10 @@ columns:
         sql: "CAST(\"cs_net_paid\"*\"cs_quantity\" AS decimal(16,2))"
   - name: cs_catalog_sales_price_tier
     data_type: string
-    sql: "CASE WHEN cs_sales_price BETWEEN 0 AND 500 THEN '500 or Less' ELSE 'More than 500' END"
+    sql: "CASE WHEN cs_sales_price > 500 THEN 'More than 500' WHEN cs_sales_price BETWEEN 0 AND 500 THEN '500 or Less' ELSE NULL END"
     dialects:
       - dialect: Snowflake
-        sql: "CASE WHEN \"cs_sales_price\" BETWEEN 0 AND 500 THEN '500 or Less' ELSE 'More than 500' END"
+        sql: "CASE WHEN \"cs_sales_price\" > 500 THEN 'More than 500' WHEN \"cs_sales_price\" BETWEEN 0 AND 500 THEN '500 or Less' ELSE NULL END"
   - name: Catalog Sales
     data_type: "decimal(16,2)"
     sql: "CAST(cs_sales_price*cs_quantity AS decimal(16,2))"

--- a/datasets/store_sales.yml
+++ b/datasets/store_sales.yml
@@ -7,7 +7,8 @@ table: store_sales
 columns:
   - name: ss_net_profit_tier
     data_type: string
-    sql: "CASE WHEN ss_net_profit > 25000 THEN 'More than 25000' 
+    sql: "CASE WHEN ss_net_profit IS NULL THEN NULL
+            WHEN ss_net_profit > 25000 THEN 'More than 25000'
             WHEN ss_net_profit BETWEEN 3000 AND 25000 THEN '3000-25000'
             WHEN ss_net_profit BETWEEN 2000 AND 3000 THEN '2000-3000'  
             WHEN ss_net_profit BETWEEN 300 AND 2000 THEN '300-2000'  
@@ -21,7 +22,8 @@ columns:
             END"
     dialects:
       - dialect: Snowflake
-        sql: "CASE WHEN \"ss_net_profit\" > 25000 THEN 'More than 25000' 
+        sql: "CASE WHEN \"ss_net_profit\" IS NULL THEN NULL
+        WHEN \"ss_net_profit\" > 25000 THEN 'More than 25000'
         WHEN \"ss_net_profit\" BETWEEN 3000 AND 25000 THEN '3000-25000'
         WHEN \"ss_net_profit\" BETWEEN 2000 AND 3000 THEN '2000-3000'  
         WHEN \"ss_net_profit\" BETWEEN 300 AND 2000 THEN '300-2000'  
@@ -41,14 +43,16 @@ columns:
         sql: "((\"ss_ext_list_price\"-\"ss_ext_wholesale_cost\"-\"ss_ext_discount_amt\")+\"ss_ext_sales_price\")/2"
   - name: sales price tier
     data_type: string
-    sql: "CASE WHEN ss_sales_price > 200 THEN '200 and More' 
+    sql: "CASE WHEN ss_sales_price IS NULL THEN NULL
+            WHEN ss_sales_price > 200 THEN '200 and More'
             WHEN ss_sales_price BETWEEN 150 AND 200 THEN '150-200' 
             WHEN ss_sales_price BETWEEN 100 AND 150 THEN '100-150' 
             WHEN ss_sales_price BETWEEN 50 AND 100 THEN ' 50-100'
             ELSE ' 50 and Less' END"
     dialects:
       - dialect: Snowflake
-        sql: "CASE WHEN \"ss_sales_price\" > 200 THEN '200 and More' 
+        sql: "CASE WHEN \"ss_sales_price\" IS NULL THEN NULL
+        WHEN \"ss_sales_price\" > 200 THEN '200 and More'
         WHEN \"ss_sales_price\" BETWEEN 150 AND 200 THEN '150-200' 
         WHEN \"ss_sales_price\" BETWEEN 100 AND 150 THEN '100-150' 
         WHEN \"ss_sales_price\" BETWEEN 50 AND 100 THEN ' 50-100'

--- a/dimensions/Customer Dimension.yml
+++ b/dimensions/Customer Dimension.yml
@@ -90,17 +90,4 @@ level_attributes:
     key_columns:
       - c_customer_sk
     name_column: c_customer_sk
-relationships:
-  - unique_name: Customer Dimension Customer Address
-    from:
-      dataset: customer
-      hierarchy: Customer Dimension
-      join_columns:
-        - c_current_addr_sk
-      level: Customer Dimension
-    role_play: Current {0}
-    to:
-      dimension: Customer Address
-      level: Customer Address
-    type: embedded
 type: standard

--- a/dimensions/Customer Dimension.yml
+++ b/dimensions/Customer Dimension.yml
@@ -98,6 +98,7 @@ relationships:
       join_columns:
         - c_current_addr_sk
       level: Customer Dimension
+    role_play: Current {0}
     to:
       dimension: Customer Address
       level: Customer Address

--- a/models/tpcds_benchmark_model.yml
+++ b/models/tpcds_benchmark_model.yml
@@ -83,8 +83,8 @@ aggregates:
     metrics:
       - Web and Catalog Sales Price Growth
     target_connection: Connection - TPCDS
-  - unique_name: Q31
-    label: Q31
+  - unique_name: Q31-Store
+    label: Q31-Store
     attributes:
       - name: Calendar Quarter
         dimension: Date Dimensions
@@ -100,11 +100,29 @@ aggregates:
         relationships_path:
           - store_sales_Date_Dimension_Sold
     metrics:
-      - Web Sales Increase
       - Store Sales Increase
     target_connection: Connection - TPCDS
-  - unique_name: Q33
-    label: Q33
+  - unique_name: Q31-Web
+    label: Q31-Web
+    attributes:
+      - name: Calendar Quarter
+        dimension: Date Dimensions
+        relationships_path:
+          - store_sales_Date_Dimension_Sold_1
+      - name: Customer County
+        dimension: Customer Address
+        relationships_path:
+          - web_sales_Customer_Address_Sold
+      - name: Calendar Year Week
+        dimension: Date Dimensions
+        partition: name
+        relationships_path:
+          - store_sales_Date_Dimension_Sold
+    metrics:
+      - Web Sales Increase
+    target_connection: Connection - TPCDS
+  - unique_name: Q33-Store
+    label: Q33-Store
     attributes:
       - name: Customer GMT Offset
         dimension: Customer Address
@@ -124,7 +142,53 @@ aggregates:
         relationships_path:
           - store_sales_Date_Dimension_Sold
     metrics:
-      - Total Ext Sales Price
+      - Store Ext Sales Price
+    target_connection: Connection - TPCDS
+  - unique_name: Q33-Catalog
+    label: Q33-Catalog
+    attributes:
+      - name: Customer GMT Offset
+        dimension: Customer Address
+        relationships_path:
+          - catalog_sales_Customer_Address_Sold
+      - name: Month of Year
+        dimension: Date Dimensions
+        relationships_path:
+          - store_sales_Date_Dimension_Sold_1
+      - name: Product Category
+        dimension: Product Dimension
+      - name: Product Manufacturer ID
+        dimension: Product Dimension
+      - name: Calendar Year Week
+        dimension: Date Dimensions
+        partition: name
+        relationships_path:
+          - store_sales_Date_Dimension_Sold
+    metrics:
+      - Catalog Ext Sales Price
+    target_connection: Connection - TPCDS
+  - unique_name: Q33-Web
+    label: Q33-Web
+    attributes:
+      - name: Customer GMT Offset
+        dimension: Customer Address
+        relationships_path:
+          - web_sales_Customer_Address_Sold
+      - name: Month of Year
+        dimension: Date Dimensions
+        relationships_path:
+          - store_sales_Date_Dimension_Sold_1
+      - name: Product Category
+        dimension: Product Dimension
+      - name: Product Manufacturer ID
+        dimension: Product Dimension
+      - name: Calendar Year Week
+        dimension: Date Dimensions
+        partition: name
+        relationships_path:
+          - store_sales_Date_Dimension_Sold
+    metrics:
+      - Web Ext Sales Price
     target_connection: Connection - TPCDS
   - unique_name: Q42
     label: Q42
@@ -252,8 +316,8 @@ aggregates:
       - Avg Quarter Sales Ratio
       - Store Ext Sales Price
     target_connection: Connection - TPCDS
-  - unique_name: Q56-Q60
-    label: Q56-Q60
+  - unique_name: Q56-Q60-Store
+    label: Q56-Q60-Store
     attributes:
       - name: Calendar Year
         dimension: Date Dimensions
@@ -275,7 +339,57 @@ aggregates:
       - name: Product Color
         dimension: Product Dimension
     metrics:
-      - Total Ext Sales Price
+      - Store Ext Sales Price
+    target_connection: Connection - TPCDS
+  - unique_name: Q56-Q60-Catalog
+    label: Q56-Q60-Catalog
+    attributes:
+      - name: Calendar Year
+        dimension: Date Dimensions
+        partition: name
+        relationships_path:
+          - store_sales_Date_Dimension_Sold_1
+      - name: Product Item ID
+        dimension: Product Dimension
+      - name: Customer GMT Offset
+        dimension: Customer Address
+        relationships_path:
+          - catalog_sales_Customer_Address_Sold
+      - name: Month of Year
+        dimension: Date Dimensions
+        relationships_path:
+          - store_sales_Date_Dimension_Sold_1
+      - name: Product Category
+        dimension: Product Dimension
+      - name: Product Color
+        dimension: Product Dimension
+    metrics:
+      - Catalog Ext Sales Price
+    target_connection: Connection - TPCDS
+  - unique_name: Q56-Q60-Web
+    label: Q56-Q60-Web
+    attributes:
+      - name: Calendar Year
+        dimension: Date Dimensions
+        partition: name
+        relationships_path:
+          - store_sales_Date_Dimension_Sold_1
+      - name: Product Item ID
+        dimension: Product Dimension
+      - name: Customer GMT Offset
+        dimension: Customer Address
+        relationships_path:
+          - web_sales_Customer_Address_Sold
+      - name: Month of Year
+        dimension: Date Dimensions
+        relationships_path:
+          - store_sales_Date_Dimension_Sold_1
+      - name: Product Category
+        dimension: Product Dimension
+      - name: Product Color
+        dimension: Product Dimension
+    metrics:
+      - Web Ext Sales Price
     target_connection: Connection - TPCDS
   - unique_name: Q61-1
     label: Q61 - Store Sales

--- a/models/tpcds_benchmark_model.yml
+++ b/models/tpcds_benchmark_model.yml
@@ -60,8 +60,8 @@ aggregates:
     metrics:
       - Catalog Sales Price
     target_connection: Connection - TPCDS
-  - unique_name: Q2-Web
-    label: Q2-Web
+  - unique_name: Q2
+    label: Q2
     attributes:
       - name: Calendar Week
         dimension: Date Dimensions
@@ -82,28 +82,6 @@ aggregates:
           - store_sales_Date_Dimension_Sold
     metrics:
       - Web Ext Sales Price
-    target_connection: Connection - TPCDS
-  - unique_name: Q2-Catalog
-    label: Q2-Catalog
-    attributes:
-      - name: Calendar Week
-        dimension: Date Dimensions
-        relationships_path:
-          - store_sales_Date_Dimension_Sold
-      - name: Day Name Week
-        dimension: Date Dimensions
-        relationships_path:
-          - store_sales_Date_Dimension_Sold
-      - name: Week Sequence
-        dimension: Date Dimensions
-        relationships_path:
-          - store_sales_Date_Dimension_Sold
-      - name: Calendar Year Week
-        dimension: Date Dimensions
-        partition: name
-        relationships_path:
-          - store_sales_Date_Dimension_Sold
-    metrics:
       - Catalog Ext Sales Price
     target_connection: Connection - TPCDS
   - unique_name: Q31-Store

--- a/models/tpcds_benchmark_model.yml
+++ b/models/tpcds_benchmark_model.yml
@@ -60,8 +60,8 @@ aggregates:
     metrics:
       - Catalog Sales Price
     target_connection: Connection - TPCDS
-  - unique_name: Q2
-    label: Q2
+  - unique_name: Q2-Web
+    label: Q2-Web
     attributes:
       - name: Calendar Week
         dimension: Date Dimensions
@@ -81,7 +81,30 @@ aggregates:
         relationships_path:
           - store_sales_Date_Dimension_Sold
     metrics:
-      - Web and Catalog Sales Price Growth
+      - Web Ext Sales Price
+    target_connection: Connection - TPCDS
+  - unique_name: Q2-Catalog
+    label: Q2-Catalog
+    attributes:
+      - name: Calendar Week
+        dimension: Date Dimensions
+        relationships_path:
+          - store_sales_Date_Dimension_Sold
+      - name: Day Name Week
+        dimension: Date Dimensions
+        relationships_path:
+          - store_sales_Date_Dimension_Sold
+      - name: Week Sequence
+        dimension: Date Dimensions
+        relationships_path:
+          - store_sales_Date_Dimension_Sold
+      - name: Calendar Year Week
+        dimension: Date Dimensions
+        partition: name
+        relationships_path:
+          - store_sales_Date_Dimension_Sold
+    metrics:
+      - Catalog Ext Sales Price
     target_connection: Connection - TPCDS
   - unique_name: Q31-Store
     label: Q31-Store
@@ -267,7 +290,6 @@ aggregates:
         dimension: Store Dimension
       - name: Calendar Year Week
         dimension: Date Dimensions
-        partition: name
         relationships_path:
           - store_returns_Date_Dimension_Return
       - name: Store State
@@ -453,8 +475,8 @@ aggregates:
     metrics:
       - Store Ext Sales Price by Promotion
     target_connection: Connection - TPCDS
-  - unique_name: Q7-Q26
-    label: Q7-Q26
+  - unique_name: Q7-Q26-Catalog
+    label: Q7-Q26-Catalog
     attributes:
       - name: Marital Status
         dimension: Customer Demographics
@@ -475,13 +497,35 @@ aggregates:
         dimension: Promotions
     metrics:
       - Catalog Sales Average Coupon Amount
-      - Average Store Sales Sales Price
       - Catalog Sales Average Quantity Sold
+      - Catalog Sales Average List Price
+      - Catalog Sales Average Sales Price
+    target_connection: Connection - TPCDS
+  - unique_name: Q7-Q26-Store
+    label: Q7-Q26-Store
+    attributes:
+      - name: Marital Status
+        dimension: Customer Demographics
+      - name: Calendar Year
+        dimension: Date Dimensions
+        partition: name
+        relationships_path:
+          - store_sales_Date_Dimension_Sold_1
+      - name: Product Item ID
+        dimension: Product Dimension
+      - name: Education Status
+        dimension: Customer Demographics
+      - name: Channel Event
+        dimension: Promotions
+      - name: Gender
+        dimension: Customer Demographics
+      - name: Channel Email
+        dimension: Promotions
+    metrics:
+      - Average Store Sales Sales Price
       - Average Store Sales Coupon Amount
       - Average Store Sales Quantity
       - Average Store Sales List Price
-      - Catalog Sales Average List Price
-      - Catalog Sales Average Sales Price
     target_connection: Connection - TPCDS
   - unique_name: Q88
     label: Q88

--- a/models/tpcds_benchmark_model.yml
+++ b/models/tpcds_benchmark_model.yml
@@ -67,7 +67,7 @@ aggregates:
         dimension: Date Dimensions
         relationships_path:
           - store_sales_Date_Dimension_Sold
-      - name: Day Name Week
+      - name: Day of Week
         dimension: Date Dimensions
         relationships_path:
           - store_sales_Date_Dimension_Sold

--- a/models/tpcds_benchmark_model.yml
+++ b/models/tpcds_benchmark_model.yml
@@ -81,8 +81,7 @@ aggregates:
         relationships_path:
           - store_sales_Date_Dimension_Sold
     metrics:
-      - Web Ext Sales Price
-      - Catalog Ext Sales Price
+      - Web and Catalog Sales Price Growth
     target_connection: Connection - TPCDS
   - unique_name: Q31-Store
     label: Q31-Store

--- a/models/tpcds_benchmark_model.yml
+++ b/models/tpcds_benchmark_model.yml
@@ -41,11 +41,11 @@ aggregates:
       - name: Customer State
         dimension: Customer Address
         relationships_path:
-          - store_sales_Customer_Address_Sold
+          - catalog_sales_Customer_Address_Sold
       - name: Customer Zip Code
         dimension: Customer Address
         relationships_path:
-          - store_sales_Customer_Address_Sold
+          - catalog_sales_Customer_Address_Sold
       - name: Calendar Year
         dimension: Date Dimensions
         partition: name
@@ -321,7 +321,7 @@ aggregates:
       - name: Customer GMT Offset
         dimension: Customer Address
         relationships_path:
-          - store_sales_Customer_Address_Sold
+          - store_promotion_Customer_Address
       - name: Month of Year
         dimension: Date Dimensions
         relationships_path:

--- a/models/tpcds_benchmark_model.yml
+++ b/models/tpcds_benchmark_model.yml
@@ -801,6 +801,7 @@ relationships:
       dataset: store_promotion
       join_columns:
         - ss_item_sk
+    role_play: Store Promoted {0}
     to:
       dimension: Product Dimension
       level: Product Dimension

--- a/models/tpcds_benchmark_model.yml
+++ b/models/tpcds_benchmark_model.yml
@@ -239,38 +239,14 @@ aggregates:
   - unique_name: Q50
     label: Q50
     attributes:
-      - name: Store Zip Code
-        dimension: Store Dimension
-      - name: Store Country
-        dimension: Store Dimension
-      - name: Store Street Type
-        dimension: Store Dimension
-      - name: Store City
-        dimension: Store Dimension
-      - name: Month of Year
-        dimension: Date Dimensions
-        relationships_path:
-          - store_returns_Date_Dimension_Return_1
-      - name: Store Company ID
-        dimension: Store Dimension
       - name: Returns Time Tier
         dimension: Returns Time Tier
-      - name: Store Name
+      - name: Store Number
         dimension: Store Dimension
-      - name: Store Street Number
-        dimension: Store Dimension
-      - name: Store Street Name
-        dimension: Store Dimension
-      - name: Store County
-        dimension: Store Dimension
-      - name: Store Suite Number
-        dimension: Store Dimension
-      - name: Calendar Year Week
+      - name: Calendar Date
         dimension: Date Dimensions
         relationships_path:
           - store_returns_Date_Dimension_Return
-      - name: Store State
-        dimension: Store Dimension
     metrics:
       - Store Returns Count
     target_connection: Connection - TPCDS
@@ -1075,7 +1051,7 @@ relationships:
     role_play: Return {0}
     to:
       dimension: Date Dimensions
-      level: Calendar Date Week
+      level: Calendar Date
   - unique_name: store_returns_Time_Dimension_Return
     from:
       dataset: store_returns
@@ -1094,15 +1070,6 @@ relationships:
     to:
       dimension: Customer Address
       level: Customer Address
-  - unique_name: store_returns_Date_Dimension_Return_1
-    from:
-      dataset: store_returns
-      join_columns:
-        - sr_returned_date_sk
-    role_play: Return {0}
-    to:
-      dimension: Date Dimensions
-      level: Calendar Date
   - unique_name: store_returns_Customer_Demographics
     from:
       dataset: store_returns

--- a/models/tpcds_benchmark_model.yml
+++ b/models/tpcds_benchmark_model.yml
@@ -13,7 +13,7 @@ aggregates:
       - name: Customer State
         dimension: Customer Address
         relationships_path:
-          - Customer Dimension Customer Address
+          - store_sales_Customer_Address_Sold
       - name: Sales Price Tier
         dimension: Sales Price Tier
       - name: Education Status
@@ -21,7 +21,7 @@ aggregates:
       - name: Customer Country
         dimension: Customer Address
         relationships_path:
-          - Customer Dimension Customer Address
+          - store_sales_Customer_Address_Sold
       - name: Calendar Year Week
         dimension: Date Dimensions
         partition: name
@@ -41,11 +41,11 @@ aggregates:
       - name: Customer State
         dimension: Customer Address
         relationships_path:
-          - Customer Dimension Customer Address
+          - store_sales_Customer_Address_Sold
       - name: Customer Zip Code
         dimension: Customer Address
         relationships_path:
-          - Customer Dimension Customer Address
+          - store_sales_Customer_Address_Sold
       - name: Calendar Year
         dimension: Date Dimensions
         partition: name
@@ -265,7 +265,7 @@ aggregates:
       - name: Customer GMT Offset
         dimension: Customer Address
         relationships_path:
-          - Customer Dimension Customer Address
+          - store_sales_Customer_Address_Sold
       - name: Month of Year
         dimension: Date Dimensions
         relationships_path:
@@ -291,7 +291,7 @@ aggregates:
       - name: Customer GMT Offset
         dimension: Customer Address
         relationships_path:
-          - Customer Dimension Customer Address
+          - store_sales_Customer_Address_Sold
       - name: Month of Year
         dimension: Date Dimensions
         relationships_path:
@@ -321,7 +321,7 @@ aggregates:
       - name: Customer GMT Offset
         dimension: Customer Address
         relationships_path:
-          - Customer Dimension Customer Address
+          - store_sales_Customer_Address_Sold
       - name: Month of Year
         dimension: Date Dimensions
         relationships_path:
@@ -759,6 +759,7 @@ relationships:
       dataset: store_promotion
       join_columns:
         - ss_addr_sk
+    role_play: Sold {0}
     to:
       dimension: Customer Address
       level: Customer Address
@@ -800,7 +801,6 @@ relationships:
       dataset: store_promotion
       join_columns:
         - ss_item_sk
-    role_play: Store Promoted {0}
     to:
       dimension: Product Dimension
       level: Product Dimension


### PR DESCRIPTION
## What changed

This branch corrects role-play paths, dimension descriptions, and several user-defined aggregates so they materialize and get matched instead of falling back to base-table scans.

### Role-play & relationship fixes
- Apply role-play prefixes to Customer Address paths and fix the Product prefix; fix cross-channel customer-address paths in Q15 and Q61-2 aggregates.
- Split multi-channel customer-address aggregates into per-channel aggregates (a single aggregate can't span multiple facts).
- Remove an embedded Current Customer Address relationship; restore the Store Promoted role-play on `store_promotion_Product_Dimension`.

### Aggregate correctness (no more base-table scans)
- **Q50** — the UDA included `Calendar Year Week` through the `store_returns_Date_Dimension_Return` (Calendar Date Week) path, which dragged in the model-level Calendar Year-Week partition (bound to a `store_sales` role / a non-existent relationship) and forced a two-date-key grain the build couldn't materialize. Reduced Q50 to a single day-grain date key via `store_returns_Date_Dimension_Return`; both the Month-of-Year and Year filters now resolve from one `date_dim` join. Verified against outbound SQL: the query now hits `as_agg_5894f740_q50` with **zero `store_returns` fact access**.
- **Q2 / Q7-Q26** — split multi-fact aggregates into per-channel components so the growth/average calcs accelerate from single-fact aggregates; fixed a Q2 attribute mismatch (Day Name Week → Day of Week).
- Fixed non-existent quarter member keys in the Avg Quarterly Store Sales baseline.

### Tier bucketing
- Exclude NULLs from the store net-profit and sales-price tier bottom buckets; fix Catalog Sales Price Tier mis-bucketing NULL prices into "More than 500".

### Descriptions
- AI-generated / refined descriptions across measures, the calendar hierarchy, customer address, product, and channel attributes.

## Why
These fixes ensure the TPC-DS benchmark queries hit their intended aggregates (confirmed via outbound SQL) rather than scanning fact tables, and clean up role-play naming and dimension metadata.

## Reviewer notes
- The bulk of the diff is in `models/tpcds_benchmark_model.yml` (aggregate + relationship definitions).
- Aggregate fixes were validated by inspecting AtScale outbound SQL and confirming the absence of fact-table scans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
